### PR TITLE
Fix recipes being visible when hidden

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -266,6 +266,7 @@ local function create_color_overlay_recipe(base_type, base_name, color_name, col
         end
     end
     if built_from_base_item then
+        color_coded_recipe.enabled = false
         color_coded_recipe.hidden_in_factoriopedia = true
     end
     local recipe_ingredient_type = settings.startup["color-coded-pipes-recipe-ingredients"].value


### PR DESCRIPTION
If the base recipe is enabled, the color coded recipes also will be enabled regardless of whether or not they are `built_from_base_item` aka hidden

This is noticeable on Periodic Madness
![image](https://github.com/user-attachments/assets/4fa42e43-3d52-4de0-905f-9fad1613560e)
